### PR TITLE
Parse all nodes and provide source for each

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const SPF = require('script-pattern-factory');
     const y = 55;
     `;
     const pattern = await SPF.getPattern(code);
-    //VvIFBECNIECIVvI
+    //VveIFIBECNIIIIECIIVveI
     console.log(`Pattern ${pattern}`);
     console.log(`Symbol Map:\n${JSON.stringify(SPF.inspect())}`);
 })();
@@ -114,7 +114,7 @@ const SPF = require('script-pattern-factory');
     const nodes = await SPF.getNodes(code);
     console.log(`Parsed ${nodes.length}:`);
     for (let node of nodes) {
-        console.log(`[${node.type.padEnd(22)}] ==> ${node.src.replace('\n', '')}`);
+        console.log(`[${node.type.padEnd(19)}] ==> ${node.src.replace('\n', '')}`);
     }
 })();
 ````

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ returns the [AST nodes mapping](https://github.com/bgauryy/ScriptPatternFactory/
 }
 ``` 
 
-## Example
+## Example - SPF.parse
 
  ````javascript
 const SPF = require('script-pattern-factory');
@@ -92,6 +92,29 @@ const SPF = require('script-pattern-factory');
     console.log(`Symbol Map:\n${JSON.stringify(SPF.inspect())}`);
 })();
 ````
+#### SPF.getNodes (source, opts)
+Traverse source code and returns its AST, complete with the code for each node. 
+- `source` (string)
+- `parse` (object) [meriyah parsing API](https://github.com/meriyah/meriyah#api). Note the location (`loc`) option is on by default and is required to extract the actual code for each node.
 
+## Example - SPF.getNodes
+ ````javascript
+const SPF = require('script-pattern-factory');
 
-
+(async function () {
+    const code = `
+    const x = 10;
+    function foo(val){
+        console.log(val);
+    }
+    foo(x);
+    ;
+    const y = 55;
+    `;
+    const nodes = await SPF.getNodes(code);
+    console.log(`Parsed ${nodes.length}:`);
+    for (let node of nodes) {
+        console.log(`[${node.type.padEnd(22)}] ==> ${node.src.replace('\n', '')}`);
+    }
+})();
+````

--- a/sample/script.js
+++ b/sample/script.js
@@ -11,7 +11,7 @@ const {getPattern, inspect} = require('../src/index');
     var y = 55;
     `;
     const pattern = await getPattern(code);
-    console.log(`Pattern ${pattern}`); //VvIFBECNIECIVvI
+    console.log(`Pattern ${pattern}`); //VveIFIBECNIIIIECIIVveI
     console.log(`Symbol Map:\n${JSON.stringify(inspect())}`);
 })();
 

--- a/sample/script2.js
+++ b/sample/script2.js
@@ -13,6 +13,6 @@ const SPF = require('../src/index');
     const nodes = await SPF.getNodes(code);
     console.log(`Parsed ${nodes.length}:`);
     for (let node of nodes) {
-        console.log(`[${node.type.padEnd(22)}] ==> ${node.src.replace('\n', '')}`);
+        console.log(`[${node.type.padEnd(19)}] ==> ${node.src.replace('\n', '')}`);
     }
 })();

--- a/sample/script2.js
+++ b/sample/script2.js
@@ -1,0 +1,18 @@
+const SPF = require('../src/index');
+
+(async function () {
+    const code = `
+    const x = 10;
+    function foo(val){
+        console.log(val);
+    }
+    foo(x);
+    ;
+    const y = 55;
+    `;
+    const nodes = await SPF.getNodes(code);
+    console.log(`Parsed ${nodes.length}:`);
+    for (let node of nodes) {
+        console.log(`[${node.type.padEnd(22)}] ==> ${node.src.replace('\n', '')}`);
+    }
+})();

--- a/src/ast.js
+++ b/src/ast.js
@@ -3,8 +3,27 @@ const {symbolMap} = require('./constants');
 
 function traversSourceCode(source, parse) {
     const root = AST.parse(source, parse);
+    const sourceLines = source.split('\n');
     const nodes = [];
     let stack = [root];
+
+    function getSrc({start, end}) {
+        // Retrieve the source of the node
+        let src = null;
+        try {
+            if (start.line < end.line) {
+                src = sourceLines[start.line - 1].substr(start.column);
+                for (let i = start.line; i < end.line; i++) {
+                    src += sourceLines[i] + '\n';
+                }
+            } else {
+                src = sourceLines[start.line - 1].substr(start.column, end.column - start.column);
+            }
+        } catch (e) {
+
+        }
+        return src;
+    }
 
     return new Promise(resolve => {
         (async function getDFS() {
@@ -12,15 +31,22 @@ function traversSourceCode(source, parse) {
             if (!node) {
                 return resolve(nodes);
             }
-            const {nodeChildren, prop} = getChildrenArray(node);
+            if (node.src === undefined) {
+                node.src = getSrc(node.loc);
+            }
+            const {nodeChildren, attrs} = getChildrenArray(node);
             const children = [];
             if (node.type !== 'Program') {
-                delete node[prop];
+                for (const attr of attrs) {
+                    delete node[attr];
+                }
                 nodes.push(node);
             }
             if (nodeChildren) {
                 for (let i = 0; i < nodeChildren.length; i++) {
-                    children.push(nodeChildren[i]);
+                    const nodeChild = nodeChildren[i];
+                    nodeChild.src = getSrc(nodeChild.loc);
+                    children.push(nodeChild);
                 }
             }
             stack = children.concat(stack);
@@ -43,53 +69,22 @@ function getNodeSymbol(node, customMap = {}) {
 }
 
 function getChildrenArray(node) {
-    let children = [];
-    let prop = '';
-
-    if (Array.isArray(node)) {
-        children = node;
-    } else if (node.body) {
-        children = Array.isArray(node.body) ? node.body : [node.body];
-        prop = 'body';
-    } else if (node.properties) {
-        children = node.properties;
-        prop = 'properties';
-    } else if (node.block) {
-        children = node.block.body;
-        prop = 'block';
-    } else if (node.expression) {
-        children = [node.expression];
-        prop = 'expression';
-    } else if (node.expressions) {
-        children = node.expressions;
-        prop = 'expressions';
-    } else if (node.argument) {
-        children = [node.argument];
-        prop = 'argument';
-    } else if (node.callee) {
-        children = [node.callee];
-        prop = 'callee';
-    } else if (node.declarations) {
-        children = node.declarations;
-        prop = 'declarations';
-    } else if (node.cases) {
-        children = node.cases;
-        prop = 'cases';
-    } else if (node.consequent) {
-        children = [node.consequent];
-        prop = 'consequent';
-    } else if (node.property) {
-        children = [node.property];
-        prop = 'property';
-    } else if (node.id) {
-        children = [node.id];
-        prop = 'id';
-    } else {
-        //TODO: impl
-    }
+    const children = [];
+    const attrs = [];
+    const ignoreAttrs = ['loc', 'src'];
+    const ignoreTypes = ['EmptyStatement', 'Literal', 'Identifier', 'ThisExpression',
+                         'ContinueStatement', 'BreakStatement'];
+    const acceptableType = ['object', 'array'];
+    if (!ignoreTypes.includes(node.type)) {
+        for (const prop of Object.keys(node)) {
+            if (acceptableType.includes(typeof node[prop]) && !ignoreAttrs.includes(prop)) {
+                attrs.push(prop);
+                children.push(node[prop]);
+            }
+        }}
     return {
-        nodeChildren: children,
-        prop
+        nodeChildren:  [].concat.apply([], children.filter(obj => obj !== null)),
+        attrs: attrs
     };
 }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -59,9 +59,7 @@ function getLinesFromSource(start, end, sourceLines) {
         } else {
             src = sourceLines[start.line - 1].substr(start.column, end.column - start.column);
         }
-    } catch (e) {
-
-    }
+    } catch (e) {}
     return src;
 }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -42,9 +42,9 @@ function traversSourceCode(source, parse) {
 function sourceGetter(source) {
     // Wrapper for getLinesFromSource to avoid splitting the same source repeatedly
     const sourceSplitLines = source.split('\n');
-    return function (start, end) {
+    return function ({start, end}) {
         return getLinesFromSource(start, end, sourceSplitLines);
-    } 
+    };
 }
 
 function getLinesFromSource(start, end, sourceLines) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const {symbolMap} = require('./constants');
 const {createPattern} = require('./pattern');
-const { traversSourceCode } = require('./ast')
+const { traversSourceCode } = require('./ast');
 
 /**
  *

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const {symbolMap} = require('./constants');
 const {createPattern} = require('./pattern');
+const { traversSourceCode } = require('./ast')
 
 /**
  *
@@ -10,6 +11,7 @@ const {createPattern} = require('./pattern');
 async function getPattern(source, opts = {}) {
     opts.input = opts.input || {};
     opts.parse = opts.parse || {};
+    opts.parse.loc = opts.parse.loc || true;
     opts.output = opts.output || {};
     return createPattern(source, opts);
 }
@@ -26,7 +28,10 @@ function inspect() {
     };
 }
 
+const getNodes = traversSourceCode;
+
 module.exports = {
     getPattern,
-    inspect
+    inspect,
+    getNodes
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ const { traversSourceCode } = require('./ast')
 async function getPattern(source, opts = {}) {
     opts.input = opts.input || {};
     opts.parse = opts.parse || {};
-    opts.parse.loc = opts.parse.loc || true;
     opts.output = opts.output || {};
     return createPattern(source, opts);
 }
@@ -28,7 +27,11 @@ function inspect() {
     };
 }
 
-const getNodes = traversSourceCode;
+async function getNodes(source, parse = {}) {
+    parse.loc = parse.loc || true;
+    return traversSourceCode(source, parse);
+}
+
 
 module.exports = {
     getPattern,


### PR DESCRIPTION
Added: 
- The src attribute to each node, containing the source code of the node
- Exported the getNodes function for when there is a need for node manipulation
Improved: 
- Generalized the extraction of child nodes, and used a blacklist to avoid edge cases