### PR TITLE
Keep Nodes' Additional Attributes

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -1,5 +1,5 @@
 const AST = require('abstract-syntax-tree');
-const {symbolMap} = require('./constants');
+const { symbolMap } = require('./constants');
 
 /**
  * 
@@ -22,11 +22,13 @@ function traversSourceCode(source, parse, opts) {
             if (node.src === undefined) {
                 node.src = node.loc ? getLinesContent(node.loc) : '';
             }
-            const {nodeChildren, attrs} = getChildrenArray(node);
+            const { nodeChildren, attrs } = getChildrenArray(node);
             const children = [];
-            if (!opts.keepAttrs && node.type !== 'Program') {
-                for (const attr of attrs) {
-                    delete node[attr];
+            if (node.type !== 'Program') {
+                if (!opts.keepAttrs) {
+                    for (const attr of attrs) {
+                        delete node[attr];
+                    }
                 }
                 nodes.push(node);
             }
@@ -52,7 +54,7 @@ function traversSourceCode(source, parse, opts) {
 function sourceGetter(source) {
     // Wrapper for getLinesFromSource to avoid splitting the same source repeatedly
     const sourceSplitLines = source.split('\n');
-    return function ({start, end}) {
+    return function ({ start, end }) {
         return getCodeFromSourceLines(start, end, sourceSplitLines);
     };
 }
@@ -76,7 +78,7 @@ function getCodeFromSourceLines(start, end, sourceLines) {
         } else if (start.line === end.line) {
             src = sourceLines[start.line - 1].slice(start.column, end.column);
         }
-    } catch (e) {}
+    } catch (e) { }
     return src;
 }
 
@@ -96,7 +98,7 @@ function getChildrenArray(node) {
     const attrs = [];
     const ignoreAttrs = ['loc', 'src'];
     const ignoreTypes = ['EmptyStatement', 'Literal', 'Identifier', 'ThisExpression',
-                         'ContinueStatement', 'BreakStatement'];
+        'ContinueStatement', 'BreakStatement'];
     const acceptableType = ['object', 'array'];
     if (!ignoreTypes.includes(node.type)) {
         for (const prop of Object.keys(node)) {
@@ -104,9 +106,10 @@ function getChildrenArray(node) {
                 attrs.push(prop);
                 children.push(node[prop]);
             }
-        }}
+        }
+    }
     return {
-        nodeChildren:  [].concat.apply([], children.filter(c => !!c)),
+        nodeChildren: [].concat.apply([], children.filter(c => !!c)),
         attrs: attrs
     };
 }

--- a/src/ast.js
+++ b/src/ast.js
@@ -1,7 +1,13 @@
 const AST = require('abstract-syntax-tree');
 const {symbolMap} = require('./constants');
 
-function traversSourceCode(source, parse) {
+/**
+ * 
+ * @param {string} source - The source code to traverse
+ * @param {Object} parse - The parsing options for the AST parser
+ * @param {Object} opts - Additional traversal options
+ */
+function traversSourceCode(source, parse, opts) {
     const root = AST.parse(source, parse);
     const getLinesContent = sourceGetter(source);
     const nodes = [];
@@ -18,7 +24,7 @@ function traversSourceCode(source, parse) {
             }
             const {nodeChildren, attrs} = getChildrenArray(node);
             const children = [];
-            if (node.type !== 'Program') {
+            if (!opts.keepAttrs && node.type !== 'Program') {
                 for (const attr of attrs) {
                     delete node[attr];
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,16 @@ function inspect() {
     };
 }
 
-async function getNodes(source, parse = {}) {
-    parse.loc = parse.loc || true;
-    return traversSourceCode(source, parse);
+/**
+ * 
+ * @param {string} source - The source code to extract node from
+ * @param {Object} parse - The AST parsing options
+ * @param {Object} opts - Additional traversal options
+ */
+async function getNodes(source, parse = {}, opts = {}) {
+    parse.loc = parse.loc || true;              // Nodes location enables saving node's source along with node information
+    opts.keepAttrs = opts.keepAttrs || false;   // Do not delete nodes' additional attributes
+    return traversSourceCode(source, parse, opts);
 }
 
 


### PR DESCRIPTION
Since in some cases we might need to parse a node's attributes, I've added an option to be passed to the traversSourceCode function to avoid deleting the additional attributes. The default is off as to not change current implementations.

Added some documentation along the way