### PR TITLE
Added hardcoded underscore (_) as symbol for yet unknown node types

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -90,7 +90,7 @@ function getNodeSymbol(node, customMap = {}) {
     if (Object.prototype.hasOwnProperty.call(symbolMap, type)) {
         return customMap[type] || symbolMap[type];
     }
-    throw new Error(type);
+    return '_';     // Hardcoded symbol for yet unknown node typess
 }
 
 function getChildrenArray(node) {


### PR DESCRIPTION
This will keep the changes to the AST pattern to a minimum when new node types will be introduced